### PR TITLE
Fix README data file name

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -5,7 +5,7 @@ This directory contains example files to demonstrate how to use the Typst API.
 ## Files
 
 - `main.typ`: A sample Typst document that uses data from a JSON file and includes an image
-- `sample-data.json`: Example JSON data to be submitted with the API request
+- `data.json`: Example JSON data to be submitted with the API request
 - `splash192.png`: A logo image used in the Typst document
 
 ## Testing the API
@@ -17,7 +17,7 @@ Once you have the API running, you can test it with:
 curl -X POST http://localhost:8080/typst/main.typ \
   -F "main.typ=@main.typ" \
   -F "splash192.png=@splash192.png" \
-  -F "data=$(cat sample-data.json)" \
+  -F "data=$(cat data.json)" \
   --output example.pdf
 ```
 
@@ -25,7 +25,7 @@ This will:
 
 1. Upload the Typst document (`main.typ`)
 2. Upload the logo image (`splash192.png`)
-3. Submit the JSON data from `sample-data.json`
+3. Submit the JSON data from `data.json`
 4. Save the resulting PDF as `example.pdf`
 
 ## Understanding the Example
@@ -37,4 +37,4 @@ The `main.typ` file demonstrates:
 - Creating a formatted document with headings, tables, and lists
 - Conditionally displaying content based on the JSON data
 
-The JSON data (`sample-data.json`) shows different data types that can be used in the Typst document. 
+The JSON data (`data.json`) shows different data types that can be used in the Typst document. 


### PR DESCRIPTION
## Summary
- update example README to reference `data.json` instead of `sample-data.json`

## Testing
- `go test ./...` *(fails: github.com/pdfcpu/pdfcpu@v0.7.0: Get https://proxy.golang.org/...: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846b7af370c8330aab69015e91f99b4