### PR TITLE
Update prerequisite Go version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Check out the `example` directory for a complete working example of how to use t
 
 For local development:
 
-- Go 1.16 or later
+- Go 1.23 or later
 - Typst CLI installed and available in your PATH
 
 For Docker deployment:


### PR DESCRIPTION
## Summary
- update README to specify Go 1.23 or later

## Testing
- `go build ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846b7b44d588330a6359561cefe29da