### PR TITLE
Add tests for getPDFFiles

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"mime/multipart"
+	"reflect"
+	"testing"
+)
+
+// helper to create a multipart.Form with the given file names
+func createForm(filenames []string) *multipart.Form {
+	files := make(map[string][]*multipart.FileHeader)
+	for _, name := range filenames {
+		files[name] = []*multipart.FileHeader{{Filename: name}}
+	}
+	return &multipart.Form{File: files}
+}
+
+func TestGetPDFFilesFiltering(t *testing.T) {
+	form := createForm([]string{
+		"pre_b.pdf",
+		"pre_a.pdf",
+		"post_c.pdf",
+		"post_b.pdf",
+		"post_a.pdf",
+		"pre_foo.txt",
+		"random.pdf",
+		"post_d.doc",
+		"pre_c.PDF",
+	})
+
+	gotPre := getPDFFiles(form, "pre_")
+	wantPre := []string{"pre_a.pdf", "pre_b.pdf", "pre_c.PDF"}
+	if !reflect.DeepEqual(gotPre, wantPre) {
+		t.Errorf("pre_ files mismatch:\nwant %v\n got %v", wantPre, gotPre)
+	}
+
+	gotPost := getPDFFiles(form, "post_")
+	wantPost := []string{"post_a.pdf", "post_b.pdf", "post_c.pdf"}
+	if !reflect.DeepEqual(gotPost, wantPost) {
+		t.Errorf("post_ files mismatch:\nwant %v\n got %v", wantPost, gotPost)
+	}
+}
+
+func TestGetPDFFilesSorted(t *testing.T) {
+	form := createForm([]string{"pre_c.pdf", "pre_a.pdf", "pre_b.pdf"})
+	got := getPDFFiles(form, "pre_")
+	want := []string{"pre_a.pdf", "pre_b.pdf", "pre_c.pdf"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expected sorted result %v, got %v", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- add `main_test.go` with tests for `getPDFFiles`
- verify prefix filtering and alphabetical ordering

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846b7a472b88330bb1b199a15815730